### PR TITLE
CVE-2019-9512, CVE-2019-9514.

### DIFF
--- a/vendor/golang.org/x/net/http2/writesched.go
+++ b/vendor/golang.org/x/net/http2/writesched.go
@@ -76,6 +76,10 @@ func (wr FrameWriteRequest) StreamID() uint32 {
 	return wr.stream.id
 }
 
+func (wr FrameWriteRequest) isControl() bool {
+	return wr.stream == nil
+}
+
 // DataSize returns the number of flow control bytes that must be consumed
 // to write this entire frame. This is 0 for non-DATA frames.
 func (wr FrameWriteRequest) DataSize() int {


### PR DESCRIPTION
This is a manual backport of the patch in https://github.com/kubernetes/kubernetes/pull/81525 for CVE-2019-9512, CVE-2019-9514. I wasn't able to get godep to function, so I ended up manually patching the vendor directory.

Need to keep this in mind so future backports don't accidentally loose this commit.